### PR TITLE
fix DI

### DIFF
--- a/ng-rollbar.js
+++ b/ng-rollbar.js
@@ -2,14 +2,14 @@
   angular.module('tandibar/ng-rollbar', []);
 
   angular.module('tandibar/ng-rollbar').config(['$provide', function($provide) {
-    $provide.decorator("$exceptionHandler", function($delegate, $window) {
+    $provide.decorator('$exceptionHandler', ['$delegate', '$window', function($delegate, $window) {
       return function (exception, cause) {
         if($window.Rollbar) {
           $window.Rollbar.error(exception, {cause: cause});
         }
         $delegate(exception, cause);
       };
-    });
+    }]);
   }]);
 
   angular.module('tandibar/ng-rollbar').provider('Rollbar', function RollbarProvider() {


### PR DESCRIPTION
Today we noticed our build fails as we directly used ng-rollbar.js.

I think either it would be nice to ignore `ng-rollbar.js` when publishing to bower or as an alternative publish it with the annotated version so other people don't run into this issue and drop ngAnnotate.

What do you think makes more sense?
