### PR TITLE
Fix the Rollbar.configure call to properly pass on the object to Rollbar

### DIFF
--- a/ng-rollbar.js
+++ b/ng-rollbar.js
@@ -55,7 +55,9 @@
       if (rollbarActivated) {
         service.Rollbar = $window.Rollbar;
 
-        service.configure = $window.Rollbar.configure;
+        service.configure = function(object) {
+	  $window.Rollbar.configure(object);
+	};
 
         service.critical = $window.Rollbar.critical;
         service.error = $window.Rollbar.error;


### PR DESCRIPTION
Calling Rollbar.configure(<object>) would not set the object values.
