### PR TITLE
Add support for webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./ng-rollbar.js');
+module.exports = 'tandibar/ng-rollbar';

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ng-rollbar",
   "version": "1.8.2",
   "description": "Rollbar integration for angular",
-  "main": "ng-rollbar.js",
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/tandibar/ng-rollbar.git"


### PR DESCRIPTION
Adding index.js at top-level for added support for webpack via NPM install. This allows for the Angular module dependency like:

import ngRollbar from 'ng-rollbar';
angular.module('app', ['ngRollbar']);
