### PR TITLE
Use $log instead of console for logging messages

### DIFF
--- a/ng-rollbar.js
+++ b/ng-rollbar.js
@@ -39,8 +39,8 @@
       rollbarActivated = false;
     };
 
-    getter.$inject = ['$window'];
-    function getter($window) {
+    getter.$inject = ['$log', '$window'];
+    function getter($log, $window) {
 
       function _bindRollbarMethod(methodName) {
         return function() {
@@ -93,7 +93,7 @@
       }
 
       function logInactiveMessage() {
-        console.warn("Rollbar is deactivated");
+        $log.warn("Rollbar is deactivated");
       }
 
       return service;


### PR DESCRIPTION
This changes logging to the injectable `$log` service instead of using the global `console` object. To the end-user, this doesn't have any apparent change. But using `$log.warn()` instead of `console.warn()` allows us to have better test coverage, which I'm also working on and should come in a future PR.
